### PR TITLE
Added a function to sync a specified note

### DIFF
--- a/simplenote.el
+++ b/simplenote.el
@@ -217,6 +217,20 @@ via the usual `-*- mode: text -*-' header line."
 (defun simplenote-file-mtime (path)
   (nth 5 (file-attributes path)))
 
+(defun simplenote-create-new-note ()
+  (let (createdate key)
+    (save-buffer)
+    (setq createdate (simplenote-file-mtime (buffer-file-name)))
+    (setq key (simplenote-create-note (encode-coding-string (buffer-string) 'utf-8 t)
+                                      (simplenote-token)
+                                      (simplenote-email)
+                                      createdate))
+    (if key
+        (progn
+          (setq simplenote-key key)
+          (message "Created note %s" key))
+      (message "Failed to create new note")) key))
+
 ;;; Push and pull buffer as note
 (defun simplenote-push-buffer ()
   (interactive)
@@ -254,20 +268,11 @@ via the usual `-*- mode: text -*-' header line."
 ;;;###autoload
 (defun simplenote-create-note-from-buffer ()
   (interactive)
-  (let (createdate key)
-    (save-buffer)
-    (setq createdate (simplenote-file-mtime (buffer-file-name)))
-    (setq key (simplenote-create-note (encode-coding-string (buffer-string) 'utf-8 t)
-                                      (simplenote-token)
-                                      (simplenote-email)
-                                      createdate))
-    (if key
-        (progn
-          (setq simplenote-key key)
-          (message "Created note %s" key)
-          (add-file-local-variable 'simplenote-key key)
-          (simplenote-push-buffer))
-      (message "Failed to create new note"))))
+  (let (key)
+    (setq key (simplenote-create-new-note))
+    (when key
+      (add-file-local-variable 'simplenote-key key)
+      (simplenote-push-buffer))))
 
 (defun simplenote-pull-buffer ()
   (interactive)


### PR DESCRIPTION
Dear dotemacs,

I want a command to sync only one note because _simplenote-sync-notes_ takes a bit long time when there are many notes since it always get indexes for all notes first. But so far _simplenote-push-buffer_ and _simplenote-pull-buffer_ are available only to a note created by _simplenote-create-note-from-buffer_.

So I modified those functions so they can be used to sync a note which isn't created by _simplenote-create-note-from-buffer_. Now they behave as below.

**simplenote-push-buffer**
1. If _simplenote-key_ is set, it works as the original function.
2. If _simplenote-key_ is not set and the note is located on existing notes dir, set _simplenote-key_ from the file name and do the same thing as 1.
3. If _simplenote-key_ is not set and the file is located on new notes dir,  do _simplenote-create-new-note_ and then rename and move it into existing notes dir.
4. Otherwise, just output error message.

**simplenote-pull-buffer**
1. If _simplenote-key_ is set, it works as the original function.
2. If _simplenote-key_ is not set and the note is located on existing notes dir, set _simplenote-key_ from the file name and do the same thing as 1.
3. Otherwise, just output error message.

I believe these changes are useful for most users :smiley:
