### PR TITLE
Improvement for the note list screen

### DIFF
--- a/simplenote.el
+++ b/simplenote.el
@@ -63,6 +63,12 @@ via the usual `-*- mode: text -*-' header line."
   :safe 'integerp
   :group 'simplenote)
 
+(defcustom simplenote-show-note-file-name t
+  "Show file name for each note in the note list."
+  :type 'boolean
+  :safe 'booleanp
+  :group 'simplenote)
+
 (defvar simplenote-mode-hook nil)
 
 (put 'simplenote-mode 'mode-class 'special)
@@ -627,7 +633,9 @@ setting."
                              (simplenote-open-note (widget-get widget :tag)))
                    headline)
     (widget-insert shorttext "\n")
-    (widget-insert "  " modify-string "\t" (propertize key 'face 'shadow) "\t")
+    (if simplenote-show-note-file-name
+      (widget-insert "  " modify-string "\t" (propertize key 'face 'shadow) "\t")
+      (widget-insert "  " modify-string "\t"))
     (widget-create 'link
                    :tag file
                    :value "Edit"


### PR DESCRIPTION
Hello @dotemacs

Here is one more request I'd like you to merge.

In the note list screen, each header line is supposed to be aligned to the length specified by _simplenote-note-head-size_. But it doesn't work as expected for the multi-byte characters like Japanese. That's because the function _length_ doesn't return the actual column size of string. I fixed that by using _string-width_ instead of _length_.

Also, I made _simplenote-note-head-size_ customizable and added a new customizable variable _simplenote-show-note-file-name_ so you can hide the file name of each note, because I think it's useless information for most users.
