### PR TITLE
Use note headline as buffer name

### DIFF
--- a/simplenote.el
+++ b/simplenote.el
@@ -368,6 +368,8 @@ setting."
     ;; Don't switch mode when set via file cookie
     (when (eq major-mode (default-value 'major-mode))
       (funcall simplenote-notes-mode))
+    ;; Rename the buffer something useful
+    (rename-buffer (simplenote2--note-headline (buffer-string)))
     ;; Refresh notes display after save
     (add-hook 'after-save-hook
               (lambda () (save-excursion (simplenote-browser-refresh)))


### PR DESCRIPTION
I just started using simplenote.el (thanks, btw!), and after opening a few notes found it impossible to keep track of which note was which. This edit just uses the note headline as a title to the buffer, rather than the file name (which is just hex garbage).
